### PR TITLE
proposal and initial image set for FB Alpha Boxart

### DIFF
--- a/FB Alpha - Arcade Games/Named_Boxarts/sources.txt
+++ b/FB Alpha - Arcade Games/Named_Boxarts/sources.txt
@@ -1,0 +1,5 @@
+The initial images in this collection were gathered by using the ADB tool to match a complete set of FB Alpha 0.2.97.38 arcade ROMs with arcade database at [http://adb.arcadeitalia.net/] .
+
+The resulting images were sized at 512px wide and renamed based on the game titles in the XML DAT.
+
+The images were matched in this priority order: cabinet image > marquee art > decal. If no art is available from that database in any of these categories, there will not be an image for that ROM in the initial image set.


### PR DESCRIPTION
I would like to put forward a set of images I gathered and formatted as "boxart" thumbnails for FB Alpha arcade ROMs.

**FB Alpha - Arcade Games/Named_Boxarts/: https://drive.google.com/drive/folders/0B4gWQ8g8Bzq3LTZRSDJmTm5RQ1E**

I think being able to see the cabinet or at least a bit of the artwork -- this is one of my favorite ways to browse through the FB Alpha game list. The images were matched in this priority order: cabinet image > marquee art > decal. If no art is available from that database in any of these categories, there will not be an image for that ROM in this set yet.

The images in this collection were gathered by using the ADB tool to match a complete set of FB Alpha 0.2.97.38 arcade ROMs with arcade database at http://adb.arcadeitalia.net/. The resulting images were sized at 512px wide and renamed based on the game titles in the XML DAT.