### PR TITLE
Add note about replaced characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ The RetroArch XMB menu can display thumbnails for any game in a playlist.
     thumbnails/Playlist_Name/Named_Type/Game_Name.png
     ```
 
+5. The following characters are replaced with `_` in the filename:
+    ```
+    &*/:`<>?\\|
+    ```
+
 ## Scrapper
 
     ./tgdb.pl retroarch/media/libretrodb/dat/Nintendo\ -\ Super\ Nintendo\ Entertainment\ System.dat  


### PR DESCRIPTION
Coming from https://github.com/libretro/RetroArch/pull/3996 , we should add a note about characters in the filename being replaced.