### PR TITLE
fix unnecessary escape character / add width guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The RetroArch XMB menu can display thumbnails for any game in a playlist.
 
 ![Screenshot](http://www.lakka.tv/doc/images/thumbnails.png)
 
-## Usage
+## Using and adding to the libretro thumbnail repository
 
 1. The thumbnails are installed into the RetroArch config's `thumbnails` directory
 
@@ -20,14 +20,14 @@ The RetroArch XMB menu can display thumbnails for any game in a playlist.
     thumbnails/Playlist_Name/Named_Type/Game_Name.png
     ```
 
-5. The following characters are replaced with `_` in the filename:
+5. The following characters in playlist titles must be replaced with `_` in the corresponding thumbnail filename:
     ```
     &*/:`<>?\|
     ```
-6. Thumbnail images submitted to this repository should not be greater than 512px wide
+6. Thumbnail images submitted to this repository should not be greater than 512px wide. Images with native widths greater than this should be scaled down to 512px wide before submission.
 
-## Scrapper
+## Scraper
 
     ./tgdb.pl retroarch/media/libretrodb/dat/Nintendo\ -\ Super\ Nintendo\ Entertainment\ System.dat  
-    mogrify -format png -resize 256x Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.jpg
-    rm Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.jpg
+    mogrify -format png -resize 512x Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.png
+    rm Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.png

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ The RetroArch XMB menu can display thumbnails for any game in a playlist.
 
 5. The following characters are replaced with `_` in the filename:
     ```
-    &*/:`<>?\\|
+    &*/:`<>?\|
     ```
+6. Thumbnail images submitted to this repository should not be greater than 512px wide
 
 ## Scrapper
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ The RetroArch XMB menu can display thumbnails for any game in a playlist.
     ```
 6. Thumbnail images submitted to this repository should not be greater than 512px wide. Images with native widths greater than this should be scaled down to 512px wide before submission.
 
-## Scraper
+## Thumbnail scraper tool
+
+These example commands can be modified to scrape thumbnail images for other systems or in other source formats. 
 
     ./tgdb.pl retroarch/media/libretrodb/dat/Nintendo\ -\ Super\ Nintendo\ Entertainment\ System.dat  
-    mogrify -format png -resize 512x Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.png
-    rm Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.png
+    mogrify -format png -resize 512x Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.jpg
+    rm Nintendo\ -\ Super\ Nintendo\ Entertainment\ System/Named_Boxarts/*.jpg
+
+Explanation:
+
+1. Retrieve the RetroArch database records for the Nintendo - Super Nintento Entertainment System
+2. Use the ImageMagick mogrify tool to convert a batch of jpg thumbnails to png format at the correct maximum width
+3. Remove the source jpg files (this third line can be removed if scraping files already in PNG format)


### PR DESCRIPTION
There is an extra backslash in the list of characters to avoid in thumbnail filenames.

This PR also adds information about the maximum width of images in the thumbnail repo.

It replaces jpg in the scraper script to png now that png is standard. It corrects 'scrapper' to 'scraper' and includes some misc grammar clarifications.